### PR TITLE
New Definitions architecture

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -38,7 +38,7 @@
 	<br />
 	<h2 class="project-tagline">{{ page.description | default: site.description | default: site.github.project_tagline }}</h2>	
 	<a href="https://theopenorganization.org/about" title="About" class="btn">About</a>
-	<a href="https://theopenorganization.org/definition" title="Definition" class="btn">Definition</a>
+	<a href="https://theopenorganization.org/definition" title="Definition" class="btn">Definitions</a>
 	<a href="https://theopenorganization.org/books" title="Books" class="btn">Books</a>
 	<a href="https://opensource.com/open-organization" title="Articles" class="btn" target="_blank">Articles</a>
 	<a href="http://theopenorganization.tv" title="Videos" class="btn" target="_blank">Videos</a>

--- a/definition.md
+++ b/definition.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: The Open Organization Definition
+title: Definitions
 permalink: /definition/
 ---
 
@@ -10,9 +10,7 @@ The Open Organization community maintains openly licensed, working definitions o
 Anyone can help improve them. Join the [Open Organization community on GitHub](https://github.com/open-organization) to get started.
 
 ## The Open Organization Definition
-{explanatory text}
-
-[Read the definition.]
+Forward-thinking organizations are embracing open principles in order to become more agile, innovative, and engaged. [The Open Organization Definition](https://theopenorganization.org/definition/open-organization-definition) outlines five characteristics of open organizations—transparency, inclusivity, adaptability, collaboration, and community—and explains how they can serve as a foundation for new organizational behaviors, systems, and structures.
 
 ## Maturity model
 How open is your organization? The Open Organization Maturity Model can help you assess your team, department, and organization. [Use the tool](https://www.ready-to-innovate.com/openorg/) and [download the text](https://github.com/open-organization/open-org-maturity-model).
@@ -21,6 +19,6 @@ How open is your organization? The Open Organization Maturity Model can help you
 A full-color, illustrated version of The Open Organization Definition is available [at Opensource.com](https://opensource.com/open-organization/resources/open-org-definition-book).
 
 ## The Open Leadership Definition
-Open organizations need open leaders, people who let open principles—like transparency, collaboration, and inclusivity—guide their approach to crafting organizational vision, setting organizational strategy, and reinforcing organizational culture. But what really makes open leadership different from other styles of leadership? The Open Leadership Definition describes the mindsets and behaviors that distinguish open leaders from other types of leaders—what these leaders *think* and *do* to create more open organizations every day. Openly licensed and collaboratively developed, the Open Leadership Definition is an accessible and practical guide to becoming the type of leader capable of motivating, assisting, and empowering others to build organizations capable of great things.
+Open organizations need open leaders, people who let open principles guide their approach to crafting organizational vision, setting organizational strategy, and reinforcing organizational culture. But what really makes open leadership different from other styles of leadership? The Open Leadership Definition describes the mindsets and behaviors that distinguish open leaders from other types of leaders—what these leaders *think* and *do* to create more open organizations every day. It's an accessible, practical guide to becoming the type of leader capable of motivating, assisting, and empowering others to build organizations capable of great things.
 
-[Read the definition.]
+**Coming soon!**

--- a/definition.md
+++ b/definition.md
@@ -4,101 +4,13 @@ title: The Open Organization Definition
 permalink: /definition/
 ---
 
-# The Open Organization Definition
+# Definitions
+{opening paragraph}
 
-## Preamble
-Openness is becoming increasingly central to the ways groups and teams of all sizes are working together to achieve shared goals. And today, the most forward-thinking organizations—whatever their missions—are embracing openness as a necessary orientation toward success. They've seen that openness can lead to:
+## The Open Organization Definition
+{explanatory text}
 
-- **Greater agility**, as members are more capable of working toward goals in unison and with shared vision;
-- **Faster innovation**, as ideas from both inside and outside the organization receive more equitable consideration and rapid experimentation, and;
-- **Increased engagement**, as members clearly see connections between their particular activities and an organization's overarching values, mission, and spirit.
+## The Open Leadership Definition
+{explanatory text}
 
-But openness is fluid. Openness is multifaceted. Openness is contested.
 
-While every organization is different—and therefore every example of an open organization is unique—we believe these five characteristics serve as the basic conditions for openness in most contexts:
-
-- Transparency
-- Inclusivity
-- Adaptability
-- Collaboration
-- Community
-
-## Characteristics of an Open Organization
-Open organizations take many shapes. Their sizes, compositions, and missions vary. But the following five characteristics are the hallmarks of any open organization.
-
-In practice, every open organization likely exemplifies each one of these characteristics differently, and to a greater or lesser extent. Moreover, some organizations that don't consider themselves open organizations might nevertheless embrace a few of them. But truly open organizations embody them all—and they connect them in powerful and productive ways.
-
-That fact makes explaining any one of the characteristics difficult without reference to the others.
-
-### Transparency
-In open organizations, transparency reigns. As much as possible (and advisable) under applicable laws, open organizations work to make their data and other materials easily accessible to both internal and external participants; they are open for any member to review them when necessary (see also _inclusivity_). Decisions are transparent to the extent that everyone affected by them understands the processes and arguments that led to them; they are open to assessment (see also _collaboration_). Work is transparent to the extent that anyone can monitor and assess a project's progress throughout its development; it is open to observation and potential revision if necessary (see also _adaptability_).
-
-In open organizations, transparency looks like:
-
-- Everyone working on a project or initiative has access to all pertinent materials by default.
-- People willingly disclose their work, invite participation on projects before those projects are complete and/or "final," and respond positively to request for additional details.
-- People affected by decisions can access and review the processes and arguments that lead to those decisions, and they can comment on and respond to them.
-- Leaders encourage others to tell stories about both their failures and their successes without fear of repercussion; associates are forthcoming about both.
-- People value both success and failures for the lessons they provide.
-- Goals are public and explicit, and people working on projects clearly indicate roles and responsibilities to enhance accountability.
-
-### Inclusivity
-Open organizations are inclusive. They not only welcome diverse points of view but also implement specific mechanisms for inviting multiple perspectives into dialog wherever and whenever possible. Interested parties and newcomers can begin assisting the organization without seeking express permission from each of its stakeholders (see also _collaboration_). Rules and protocols for participation are clear (see also _transparency_) and operate according to vetted and common standards.
-
-In open organizations, inclusivity looks like:
-
-- Technical channels and social norms for encouraging diverse points of view are well-established and obvious.
-- Protocols and procedures for participation are clear, widely available, and acknowledged, allowing for constructive inclusion of diverse perspectives.
-- The organization features multiple channels and/or methods for receiving feedback in order to accommodate people's preferences.
-- Leaders regularly assess and respond to feedback they receive, and cultivate a culture that encourages frequent dialog regarding this feedback.
-- Leaders are conscious of voices not present in dialog and actively seek to include or incorporate them.
-- People feel a duty to voice opinions on issues relevant to their work or about which they are passionate.
-- People work transparently and share materials via common standards and/or agreed-upon platforms that do not prevent others from accessing or modifying them.
-
-### Adaptability
-Open organizations are flexible and resilient organizations. Organizational policies and technical apparatuses ensure that both positive and negative feedback loops have a genuine and material effect on organizational operation; participants can control and potentially alter the conditions under which they work. They report frequently and thoroughly on the outcomes of their endeavors (see also _transparency_) and suggest adjustments to collective action based on assessments of these outcomes. In this way, open organizations are fundamentally oriented toward continuous engagement and learning.
-
-In open organizations, adaptability looks like:
-
-- Feedback mechanisms are accessible both to members of the organization and to outside members, who can offer suggestions.
-- Feedback mechanisms allow and encourage peers to assist one another without managerial oversight, if necessary.
-- Leaders work to ensure that feedback loops genuinely and materially impact the ways people in the organization operate.
-- Processes for collective problem solving, collaborative decision making, and continuous learning are in place, and the organization rewards both personal and team learning to reinforce a growth mindset.
-- People tend to understand the context for the changes they're making or experiencing.
-- People are not afraid to make mistakes, yet projects and teams are comfortable adapting their pre-existing work to project-specific contexts in order to avoid repeated failures.
-
-### Collaboration
-Work in an open organization involves multiple parties by default. Participants believe that joint work produces better (more effective, more sustainable) outcomes, and specifically seek to involve others in their efforts (see also _inclusivity_). Products of work in open organizations afford additional enhancement and revision, even by those not affiliated with the organization (see also, _adaptability_).
-
-In open organizations, collaboration looks like:
-
-- People tend to believe that working together produces better results.
-- People tend to begin work collaboratively, rather than "add collaboration" after they've each completed individual components of work.
-- People tend to engage partners outside their immediate teams when undertaking new projects.
-- Work produced collaboratively is easily available internally for others to build upon.
-- Work produced collaboratively is available externally for creators outside the organization to use in potentially unforeseen ways.
-- People can discover, provide feedback on, and join work in progress easily—and are welcomed to do so.
-
-### Community
-Open organizations are communal. Shared values and purpose guide participation in open organizations, and these values—more so than arbitrary geographical locations or hierarchical positions—help determine the organization's boundaries and conditions of participation. Core values are clear, but also subject to continual revision and critique, and are instrumental in defining conditions for an organization's success or failure (see also _adaptability_).
-
-In open organizations, community looks like:
-
-- Shared values and principles that inform decision-making and assessment processes are clear and obvious to members.
-- People feel equipped and empowered to make meaningful contributions to collaborative work.
-- Leaders mentor others and demonstrate strong accountability to the group by modeling shared values and principles.
-- People have a common language and work together to ensure that ideas do not get "lost in translation," and they are comfortable sharing their knowledge and stories to further the group's work.
-
-## Revision History
-Version 2.0  
-Updated April 2017  
-The Open Organization Ambassadors  
-[Suggest a revision](https://github.com/open-organization/open-org-definition)
-
-## More Resources
-
-### Additional Formats
-A full-color, illustrated version of The Open Organization Definition is available [at Opensource.com](https://opensource.com/open-organization/resources/open-org-definition-book).
-
-### Maturity Model
-How open is your organization? The Open Organization Maturity Model can help you assess your team, department, and organization. [Use the tool](https://www.ready-to-innovate.com/openorg/) and [download the text](https://github.com/open-organization/open-org-maturity-model).

--- a/definition.md
+++ b/definition.md
@@ -5,12 +5,22 @@ permalink: /definition/
 ---
 
 # Definitions
-{opening paragraph}
+The Open Organization community maintains openly licensed, working definitions of concepts central to its work.
+
+Anyone can help improve them. Join the [Open Organization community on GitHub](https://github.com/open-organization) to get started.
 
 ## The Open Organization Definition
 {explanatory text}
 
+[Read the definition.]
+
+## Maturity model
+How open is your organization? The Open Organization Maturity Model can help you assess your team, department, and organization. [Use the tool](https://www.ready-to-innovate.com/openorg/) and [download the text](https://github.com/open-organization/open-org-maturity-model).
+
+## Illustrated guide
+A full-color, illustrated version of The Open Organization Definition is available [at Opensource.com](https://opensource.com/open-organization/resources/open-org-definition-book).
+
 ## The Open Leadership Definition
-{explanatory text}
+Open organizations need open leaders, people who let open principles—like transparency, collaboration, and inclusivity—guide their approach to crafting organizational vision, setting organizational strategy, and reinforcing organizational culture. But what really makes open leadership different from other styles of leadership? The Open Leadership Definition describes the mindsets and behaviors that distinguish open leaders from other types of leaders—what these leaders *think* and *do* to create more open organizations every day. Openly licensed and collaboratively developed, the Open Leadership Definition is an accessible and practical guide to becoming the type of leader capable of motivating, assisting, and empowering others to build organizations capable of great things.
 
-
+[Read the definition.]

--- a/open-organization-definition.md
+++ b/open-organization-definition.md
@@ -1,0 +1,96 @@
+---
+layout: default
+title: The Open Organization Definition
+permalink: /definition/open-organization-definition/
+---
+
+# The Open Organization Definition
+
+## Preamble
+Openness is becoming increasingly central to the ways groups and teams of all sizes are working together to achieve shared goals. And today, the most forward-thinking organizations—whatever their missions—are embracing openness as a necessary orientation toward success. They've seen that openness can lead to:
+
+- **Greater agility**, as members are more capable of working toward goals in unison and with shared vision;
+- **Faster innovation**, as ideas from both inside and outside the organization receive more equitable consideration and rapid experimentation, and;
+- **Increased engagement**, as members clearly see connections between their particular activities and an organization's overarching values, mission, and spirit.
+
+But openness is fluid. Openness is multifaceted. Openness is contested.
+
+While every organization is different—and therefore every example of an open organization is unique—we believe these five characteristics serve as the basic conditions for openness in most contexts:
+
+- Transparency
+- Inclusivity
+- Adaptability
+- Collaboration
+- Community
+
+## Characteristics of an Open Organization
+Open organizations take many shapes. Their sizes, compositions, and missions vary. But the following five characteristics are the hallmarks of any open organization.
+
+In practice, every open organization likely exemplifies each one of these characteristics differently, and to a greater or lesser extent. Moreover, some organizations that don't consider themselves open organizations might nevertheless embrace a few of them. But truly open organizations embody them all—and they connect them in powerful and productive ways.
+
+That fact makes explaining any one of the characteristics difficult without reference to the others.
+
+### Transparency
+In open organizations, transparency reigns. As much as possible (and advisable) under applicable laws, open organizations work to make their data and other materials easily accessible to both internal and external participants; they are open for any member to review them when necessary (see also *inclusivity*). Decisions are transparent to the extent that everyone affected by them understands the processes and arguments that led to them; they are open to assessment (see also *collaboration*). Work is transparent to the extent that anyone can monitor and assess a project's progress throughout its development; it is open to observation and potential revision if necessary (see also *adaptability*).
+
+In open organizations, transparency looks like:
+
+- Everyone working on a project or initiative has access to all pertinent materials by default.
+- People willingly disclose their work, invite participation on projects before those projects are complete and/or "final," and respond positively to request for additional details.
+- People affected by decisions can access and review the processes and arguments that lead to those decisions, and they can comment on and respond to them.
+- Leaders encourage others to tell stories about both their failures and their successes without fear of repercussion; associates are forthcoming about both.
+- People value both success and failures for the lessons they provide.
+- Goals are public and explicit, and people working on projects clearly indicate roles and responsibilities to enhance accountability.
+
+### Inclusivity
+Open organizations are inclusive. They not only welcome diverse points of view but also implement specific mechanisms for inviting multiple perspectives into dialog wherever and whenever possible. Interested parties and newcomers can begin assisting the organization without seeking express permission from each of its stakeholders (see also *collaboration*). Rules and protocols for participation are clear (see also *transparency*) and operate according to vetted and common standards.
+
+In open organizations, inclusivity looks like:
+
+- Technical channels and social norms for encouraging diverse points of view are well-established and obvious.
+- Protocols and procedures for participation are clear, widely available, and acknowledged, allowing for constructive inclusion of diverse perspectives.
+- The organization features multiple channels and/or methods for receiving feedback in order to accommodate people's preferences.
+- Leaders regularly assess and respond to feedback they receive, and cultivate a culture that encourages frequent dialog regarding this feedback.
+- Leaders are conscious of voices not present in dialog and actively seek to include or incorporate them.
+- People feel a duty to voice opinions on issues relevant to their work or about which they are passionate.
+- People work transparently and share materials via common standards and/or agreed-upon platforms that do not prevent others from accessing or modifying them.
+
+### Adaptability
+Open organizations are flexible and resilient organizations. Organizational policies and technical apparatuses ensure that both positive and negative feedback loops have a genuine and material effect on organizational operation; participants can control and potentially alter the conditions under which they work. They report frequently and thoroughly on the outcomes of their endeavors (see also *transparency*) and suggest adjustments to collective action based on assessments of these outcomes. In this way, open organizations are fundamentally oriented toward continuous engagement and learning.
+
+In open organizations, adaptability looks like:
+
+- Feedback mechanisms are accessible both to members of the organization and to outside members, who can offer suggestions.
+- Feedback mechanisms allow and encourage peers to assist one another without managerial oversight, if necessary.
+- Leaders work to ensure that feedback loops genuinely and materially impact the ways people in the organization operate.
+- Processes for collective problem solving, collaborative decision making, and continuous learning are in place, and the organization rewards both personal and team learning to reinforce a growth mindset.
+- People tend to understand the context for the changes they're making or experiencing.
+- People are not afraid to make mistakes, yet projects and teams are comfortable adapting their pre-existing work to project-specific contexts in order to avoid repeated failures.
+
+### Collaboration
+Work in an open organization involves multiple parties by default. Participants believe that joint work produces better (more effective, more sustainable) outcomes, and specifically seek to involve others in their efforts (see also *inclusivity*). Products of work in open organizations afford additional enhancement and revision, even by those not affiliated with the organization (see also, *adaptability*).
+
+In open organizations, collaboration looks like:
+
+- People tend to believe that working together produces better results.
+- People tend to begin work collaboratively, rather than "add collaboration" after they've each completed individual components of work.
+- People tend to engage partners outside their immediate teams when undertaking new projects.
+- Work produced collaboratively is easily available internally for others to build upon.
+- Work produced collaboratively is available externally for creators outside the organization to use in potentially unforeseen ways.
+- People can discover, provide feedback on, and join work in progress easily—and are welcomed to do so.
+
+### Community
+Open organizations are communal. Shared values and purpose guide participation in open organizations, and these values—more so than arbitrary geographical locations or hierarchical positions—help determine the organization's boundaries and conditions of participation. Core values are clear, but also subject to continual revision and critique, and are instrumental in defining conditions for an organization's success or failure (see also *adaptability*).
+
+In open organizations, community looks like:
+
+- Shared values and principles that inform decision-making and assessment processes are clear and obvious to members.
+- People feel equipped and empowered to make meaningful contributions to collaborative work.
+- Leaders mentor others and demonstrate strong accountability to the group by modeling shared values and principles.
+- People have a common language and work together to ensure that ideas do not get "lost in translation," and they are comfortable sharing their knowledge and stories to further the group's work.
+
+## Revision History
+Version 2.0  
+Updated April 2017  
+The Open Organization Ambassadors  
+[Suggest a revision](https://github.com/open-organization/open-org-definition)


### PR DESCRIPTION
This PR suggests a new architecture for the Definitions section of the project website. In particular, it:

- Renames the topmost link from ``Definition`` to ``Definitions``
- Rewrites ``/definition/`` page as a landing page
- Adds a new page for the Open Organization Definition
- Prepares space for the forthcoming Open Leadership Definition

This is related to #20.